### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code
@@ -36,6 +38,8 @@ jobs:
 
   markdown-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code
@@ -60,6 +64,9 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
     - name: Aqua Security Trivy
       uses: aquasecurity/trivy-action@0.31.0


### PR DESCRIPTION
Potential fix for [https://github.com/SeanCondon/meter-daily-csv-to-google-form/security/code-scanning/4](https://github.com/SeanCondon/meter-daily-csv-to-google-form/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for each job. For example:
- The `build` job only needs read access to repository contents.
- The `markdown-lint` job also only needs read access to repository contents.
- The `security-scan` job does not require any permissions beyond read access to repository contents.

The `permissions` block can be added at the job level for each job or at the root level of the workflow to apply to all jobs. In this case, adding permissions at the job level provides more granular control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
